### PR TITLE
unmount added

### DIFF
--- a/example/umount/umount.go
+++ b/example/umount/umount.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/vgough/go-fuse-c/fuse"
+)
+
+func mount(mountpoint string) {
+	args := []string{"", mountpoint}
+	ops := &fuse.DefaultFileSystem{}
+
+	fmt.Println("fuse main returned", fuse.MountAndRun(args, ops))
+
+	os.Remove(mountpoint)
+}
+
+func main() {
+	mountpoint := "mnt"
+
+	if err := os.Mkdir(mountpoint, 0755); err != nil {
+		panic(err)
+	}
+
+	go mount(mountpoint)
+
+	time.Sleep(5 * time.Second)
+
+	fuse.UMount("mnt")
+}

--- a/fuse/mount.go
+++ b/fuse/mount.go
@@ -29,3 +29,9 @@ func MountAndRun(args []string, fs FileSystem) int {
 	argc := C.int(len(argv))
 	return int(C.MountAndRun(C.int(id), argc, &argv[0]))
 }
+
+func UMount(mountpoint string) {
+	arg := C.CString(mountpoint)
+
+	C.fuse_unmount(arg, nil)
+}


### PR DESCRIPTION
Unmount method is added in `mount.go`. With this, now it's possible to unmount filesystem (terminate `MountAndRun`) inside the code. See [example/umount](https://github.com/paddlesteamer/go-fuse-c/blob/master/example/umount/umount.go) for usage. 

Closes #1 